### PR TITLE
BLCIP-212 Fixed memory leak when synchronous update was enabled

### DIFF
--- a/src/osgEarthDrivers/engine_mp/TilePagedLOD
+++ b/src/osgEarthDrivers/engine_mp/TilePagedLOD
@@ -98,7 +98,6 @@ namespace osgEarth { namespace Drivers { namespace MPTerrainEngine
         optional<osg::BoundingBox>       _bbox;
         bool                             _debug;
         bool                             _synchronousUpdate;
-        bool                             _isRegistred;
     };
 
 } } } // namespace osgEarth::Drivers::MPTerrainEngine

--- a/src/osgEarthDrivers/engine_mp/TilePagedLOD.cpp
+++ b/src/osgEarthDrivers/engine_mp/TilePagedLOD.cpp
@@ -108,8 +108,7 @@ _engineUID          ( engineUID ),
 _live               ( live ),
 _dead               ( dead ),
 _debug              ( false ),
-_synchronousUpdate  ( false ),
-_isRegistred        ( false )
+_synchronousUpdate  ( false )
 {
     if ( live )
     {
@@ -357,15 +356,18 @@ TilePagedLOD::traverse(osg::NodeVisitor& nv)
                                 setTimeStamp(getNumChildren(), timeStamp);
                                 setFrameNumber(getNumChildren(), frameNumber);
                                 addChild(childNode);
-                                if (!_isRegistred)
+
+                                osgDB::DatabasePager* pager = dynamic_cast<osgDB::DatabasePager*>(nv.getDatabaseRequestHandler());
+                                if (pager)
                                 {
-                                    osgDB::DatabasePager* pager = dynamic_cast<osgDB::DatabasePager*>(nv.getDatabaseRequestHandler());
-                                    if (pager)
-                                    {
-                                        pager->registerPagedLODs(this, frameNumber);
+                                    pager->registerPagedLODs(this, frameNumber);
+
+                                    // do a fake request to ensure the database threads are started when synchronous update is used
+                                    if (!pager->isRunning()) {
+                                        pager->requestNodeFile(filePath, nv.getNodePath(), priority, nv.getFrameStamp(), _perRangeDataList[numChildren]._databaseRequest, _databaseOptions.get());
                                     }
-                                    _isRegistred = true;
                                 }
+
                                 _children[getNumChildren()-1]->accept(nv);
                             }
                         }


### PR DESCRIPTION
- With synchronous update enabled and no other component using the database pager a memory leak can occur because
  no thread is started that frees outdated PagedLODs
